### PR TITLE
test: ゴールデンクエリに表記揺れケースを追加

### DIFF
--- a/config/adr_search_golden_queries.yml
+++ b/config/adr_search_golden_queries.yml
@@ -31,3 +31,10 @@ queries:
     expect:
       - engagement: spotlight-rails
         number: 37
+  # 表記揺れ（カタカナ⇄英語）を埋め込み経路が吸収できることの回帰確認。
+  # keyword 検索「ペイロード」が0件になった実事例（取り逃がし報告 2026-08-04、
+  # ADR 本文は "payload" と英語表記）に由来する
+  - query: "ペイロードの内容をどう検証するか決めたことは？"
+    expect:
+      - engagement: spotlight-rails
+        number: 34


### PR DESCRIPTION
取り逃がし報告 #1（keyword「ペイロード」0件、ADR本文は payload 表記）に由来。埋め込み経路が表記揺れを吸収できることを回帰テストで固定する。案件横断で rank 1 を確認済み。マージ後、次回の search_eval から反映（期待値: recall@10 = 1.000 維持）。