### PR TITLE
feat(admin): ADR一覧に自然言語検索を追加

### DIFF
--- a/app/actions/adr_management/search_natural_language.rb
+++ b/app/actions/adr_management/search_natural_language.rb
@@ -13,9 +13,11 @@ module AdrManagement
 
     ScoredAdr = Data.define(:adr, :score)
 
-    def initialize(query:, engagement: nil, limit: 10, embedding_client: Sakura::EmbeddingClient.new)
+    # adr_scope: 検索対象を絞り込んだ ADR のリレーション。案件・ステータス・
+    # キーワード等の条件は呼び出し側が SQL で表現して渡す
+    def initialize(query:, adr_scope: Adr.all, limit: 10, embedding_client: Sakura::EmbeddingClient.new)
       @query = query
-      @engagement = engagement
+      @adr_scope = adr_scope
       @limit = limit
       @embedding_client = embedding_client
     end
@@ -51,10 +53,11 @@ module AdrManagement
       Rails.error.report(e, handled: true)
     end
 
+    # 絞り込みはスコア計算の前（チャンクの取得段階）に適用する。上位 limit 件へ
+    # 切り詰めてから絞り込むと、条件に合う ADR が limit 件未満しか残らず
+    # 結果が目減りするため、対象の絞り込みは SQL 側で完結させる
     def scoped_chunks
-      chunks = AdrChunk.joins(:adr)
-      chunks = chunks.where(adr_management_adrs: { engagement_id: @engagement.id }) if @engagement
-      chunks
+      AdrChunk.where(adr_id: @adr_scope.select(:id))
     end
 
     def best_scores_per_adr(query_vector)
@@ -70,7 +73,7 @@ module AdrManagement
     end
 
     def load_scored_adrs(scored)
-      adrs = Adr.where(id: scored.map(&:first)).index_by(&:id)
+      adrs = Adr.includes(:engagement).where(id: scored.map(&:first)).index_by(&:id)
       scored.map { |adr_id, score| ScoredAdr.new(adr: adrs.fetch(adr_id), score: score) }
     end
   end

--- a/app/controllers/admin/adr_management/adrs_controller.rb
+++ b/app/controllers/admin/adr_management/adrs_controller.rb
@@ -12,6 +12,7 @@ module Admin
 
       def show
         @revisions = @adr.revisions.recent_first
+        @quality_assessments = latest_quality_assessments_by_layer
       end
 
       def new
@@ -101,6 +102,15 @@ module Admin
           ::AdrManagement::Adr.find(params[:id])
         else
           ::AdrManagement::Adr.find_by_display_number!(params[:id])
+        end
+      end
+
+      # 層ごとの最新評価が現在の品質状態を表す。新しい評価の作成時に同じ層の
+      # 旧評価の未処理所見は自動クローズされるため、未処理所見は最新の1件にしか
+      # 残らない。評価が無い層は nil（未評価）として表示する
+      def latest_quality_assessments_by_layer
+        ::AdrManagement::QualityAssessment::LAYERS.index_with do |layer|
+          @adr.quality_assessments.where(layer: layer).recent_first.first
         end
       end
 

--- a/app/controllers/admin/adr_management/adrs_controller.rb
+++ b/app/controllers/admin/adr_management/adrs_controller.rb
@@ -3,11 +3,22 @@
 module Admin
   module AdrManagement
     class AdrsController < BaseController
+      # 自然言語検索は関連度順の上位のみを返す。一覧の既定表示（絞り込みのみ・
+      # 全件）と違い件数上限を設ける必要があるため、画面で扱える範囲の件数にする
+      NATURAL_LANGUAGE_LIMIT = 30
+
       before_action :set_adr, only: %i[show edit update destroy]
 
       def index
         @engagements = ::AdrManagement::Engagement.order(:code)
-        @adrs = filtered_adrs
+        @natural_language_limit = NATURAL_LANGUAGE_LIMIT
+        @query = params[:query].to_s.strip
+
+        if @query.present?
+          search_by_natural_language
+        else
+          @adrs = ordered(filtered_adrs)
+        end
       end
 
       def show
@@ -114,12 +125,56 @@ module Admin
         end
       end
 
+      # 自然言語検索の検索対象にもなるため、表示用の並び順と関連付けの
+      # 先読みは含めない（絞り込み条件だけを表すリレーションを返す）
       def filtered_adrs
-        adrs = ::AdrManagement::Adr.includes(:engagement).order(decided_on: :desc, id: :desc)
+        adrs = ::AdrManagement::Adr.all
         adrs = adrs.where(engagement_id: params[:engagement_id]) if params[:engagement_id].present?
         adrs = adrs.where(status: params[:status]) if params[:status].present?
         adrs = adrs.keyword_match(params[:keyword]) if params[:keyword].present?
         adrs
+      end
+
+      def ordered(adrs)
+        adrs.includes(:engagement).order(decided_on: :desc, id: :desc)
+      end
+
+      # 絞り込み後の ADR を対象に関連度順で上位を返す。埋め込み API が使えない
+      # ときは画面を失敗させず、絞り込みのみの一覧に縮退する（索引は自然言語
+      # 検索専用であり、DB を参照する一覧は索引が古くても正しさを保つ）
+      def search_by_natural_language
+        result = ::AdrManagement::SearchNaturalLanguage.perform(
+          query: @query, adr_scope: filtered_adrs, limit: NATURAL_LANGUAGE_LIMIT
+        )
+
+        if result.failure?
+          flash.now[:alert] = result.errors.map(&:message).join(" / ")
+          @adrs = ordered(filtered_adrs)
+          return
+        end
+
+        @adrs = result.data.map(&:adr)
+        @relevance_scores = result.data.to_h { |scored| [ scored.adr.id, scored.score ] }
+        record_natural_language_search_log(result.data)
+      end
+
+      # 0件検索は管理画面のレビューキュー、実行数・0件率は検索品質レポートの
+      # 母数になる。指標が Agent 経由の検索に偏らないよう管理画面からの検索も残す
+      def record_natural_language_search_log(scored)
+        engagement = if params[:engagement_id].present?
+          ::AdrManagement::Engagement.find_by(id: params[:engagement_id])
+        end
+
+        ::AdrManagement::SearchLog.record(
+          mode: "natural_language",
+          query: @query,
+          keyword: params[:keyword].presence,
+          engagement: engagement,
+          filters: { status: params[:status].presence },
+          results: scored.map { |entry| { adr_id: entry.adr.id, score: entry.score.round(4) } },
+          result_count: scored.size,
+          origin: web_origin
+        )
       end
 
       # フォームの選択肢。プロジェクトと置換対象は同一案件のものに限られるため、

--- a/app/helpers/admin/adr_management_helper.rb
+++ b/app/helpers/admin/adr_management_helper.rb
@@ -23,6 +23,27 @@ module Admin
       "engagement_changed" => "案件変更"
     }.freeze
 
+    ADR_QUALITY_LAYER_LABELS = {
+      "rule" => "ルール",
+      "llm" => "LLM"
+    }.freeze
+
+    # 所見の処理結果。未処理（review_result 未設定）も表示上のラベルを持つため
+    # nil をキーに含める
+    ADR_FINDING_RESULT_LABELS = {
+      nil => "未処理",
+      "addressed" => "修正済み",
+      "dismissed" => "誤検知",
+      "obsolete" => "失効"
+    }.freeze
+
+    ADR_FINDING_RESULT_BADGE_CLASSES = {
+      nil => "bg-amber-100 text-amber-800",
+      "addressed" => "bg-green-100 text-green-800",
+      "dismissed" => "bg-zinc-200 text-zinc-600",
+      "obsolete" => "bg-zinc-200 text-zinc-600"
+    }.freeze
+
     def adr_status_label(status)
       ADR_STATUS_LABELS.fetch(status, status)
     end
@@ -33,6 +54,18 @@ module Admin
 
     def adr_change_type_label(change_type)
       ADR_CHANGE_TYPE_LABELS.fetch(change_type, change_type)
+    end
+
+    def adr_quality_layer_label(layer)
+      ADR_QUALITY_LAYER_LABELS.fetch(layer, layer)
+    end
+
+    def adr_finding_result_label(review_result)
+      ADR_FINDING_RESULT_LABELS.fetch(review_result.presence, review_result)
+    end
+
+    def adr_finding_result_badge_class(review_result)
+      ADR_FINDING_RESULT_BADGE_CLASSES.fetch(review_result.presence, "bg-zinc-200 text-zinc-600")
     end
 
     def render_adr_markdown(text)

--- a/app/mcp/tools/search_adrs_tool.rb
+++ b/app/mcp/tools/search_adrs_tool.rb
@@ -116,8 +116,10 @@ module Tools
     end
 
     def self.natural_language_search(query, filters, limit, origin)
+      scope = AdrManagement::Adr.all
+      scope = scope.where(engagement: filters[:engagement]) if filters[:engagement]
       result = AdrManagement::SearchNaturalLanguage.perform(
-        query: query, engagement: filters[:engagement], limit: limit
+        query: query, adr_scope: scope, limit: limit
       )
       return error_response(result.errors) if result.failure?
 
@@ -237,21 +239,12 @@ module Tools
       text_response(guidance.join("\n"))
     end
 
-    # 検索ログの記録失敗で検索本体を失敗させない（索引更新と同じ
-    # ベストエフォート方針。ログは分析用であり検索の契約に含めない）
     def self.record_search_log(mode:, filters:, origin:, results:, result_count:, query: nil, keyword: nil)
-      AdrManagement::SearchLog.create!(
+      AdrManagement::SearchLog.record(
         mode: mode, query: query, keyword: keyword,
-        engagement: filters[:engagement],
-        filters: loggable_filters(filters),
+        engagement: filters[:engagement], filters: filters.except(:engagement),
         results: results, result_count: result_count, origin: origin
       )
-    rescue => e
-      Rails.error.report(e, handled: true)
-    end
-
-    def self.loggable_filters(filters)
-      filters.except(:engagement).compact.transform_values(&:to_s)
     end
   end
 end

--- a/app/models/adr_management/search_log.rb
+++ b/app/models/adr_management/search_log.rb
@@ -19,6 +19,21 @@ module AdrManagement
     scope :pending_review, -> { where(result_count: 0, reviewed_at: nil) }
     scope :recent_first, -> { order(created_at: :desc, id: :desc) }
 
+    # 検索の実行記録を残す。記録の失敗で検索本体を失敗させない（索引更新と
+    # 同じベストエフォート方針。ログは分析用であり検索の契約に含めない）。
+    # MCP ツールと管理画面の双方から呼ばれるため、集計対象となる値の作り方
+    # （案件の分離・フィルタの文字列化）はここに集約する
+    def self.record(mode:, origin:, results:, result_count:,
+                    query: nil, keyword: nil, engagement: nil, filters: {})
+      create!(
+        mode: mode, query: query, keyword: keyword, engagement: engagement,
+        filters: filters.compact.transform_values(&:to_s),
+        results: results, result_count: result_count, origin: origin
+      )
+    rescue => e
+      Rails.error.report(e, handled: true)
+    end
+
     # 期間内の検索実行数（モード別）と0件検索の数を集計して返す
     def self.summary(since:)
       logs = where(created_at: since..)

--- a/app/views/admin/adr_management/adrs/index.html.erb
+++ b/app/views/admin/adr_management/adrs/index.html.erb
@@ -6,21 +6,32 @@
 </div>
 
 <div class="bg-white shadow rounded-lg p-4 mb-6">
-  <%= form_with(url: admin_adr_management_adrs_path, method: :get, class: "flex flex-wrap items-end gap-4") do |form| %>
+  <%= form_with(url: admin_adr_management_adrs_path, method: :get, class: "space-y-4") do |form| %>
     <div>
-      <%= form.label :engagement_id, "案件", class: "block text-xs font-medium text-zinc-500" %>
-      <%= form.collection_select :engagement_id, @engagements, :id, :name, { include_blank: "すべて", selected: params[:engagement_id] }, class: "mt-1 rounded-md border-zinc-300 shadow-sm sm:text-sm" %>
+      <%= form.label :query, "自然言語検索", class: "block text-xs font-medium text-zinc-500" %>
+      <%= form.text_field :query, value: @query, placeholder: "例: 認証まわりで過去に決めたことは？", class: "mt-1 block w-full rounded-md border-zinc-300 shadow-sm sm:text-sm" %>
+      <p class="mt-1 text-xs text-zinc-500">
+        下の条件で絞り込んだ ADR を関連度順に上位 <%= @natural_language_limit %> 件まで表示します。
+        言い換えに弱いため、見つからないときは別の言い回しやキーワード検索も試してください。
+        空欄の場合は決定日の新しい順に一覧表示します。
+      </p>
     </div>
-    <div>
-      <%= form.label :status, "ステータス", class: "block text-xs font-medium text-zinc-500" %>
-      <%= form.select :status, ::AdrManagement::Adr::STATUSES.map { |s| [ adr_status_label(s), s ] }, { include_blank: "すべて", selected: params[:status] }, class: "mt-1 rounded-md border-zinc-300 shadow-sm sm:text-sm" %>
+    <div class="flex flex-wrap items-end gap-4">
+      <div>
+        <%= form.label :engagement_id, "案件", class: "block text-xs font-medium text-zinc-500" %>
+        <%= form.collection_select :engagement_id, @engagements, :id, :name, { include_blank: "すべて", selected: params[:engagement_id] }, class: "mt-1 rounded-md border-zinc-300 shadow-sm sm:text-sm" %>
+      </div>
+      <div>
+        <%= form.label :status, "ステータス", class: "block text-xs font-medium text-zinc-500" %>
+        <%= form.select :status, ::AdrManagement::Adr::STATUSES.map { |s| [ adr_status_label(s), s ] }, { include_blank: "すべて", selected: params[:status] }, class: "mt-1 rounded-md border-zinc-300 shadow-sm sm:text-sm" %>
+      </div>
+      <div class="grow max-w-xs">
+        <%= form.label :keyword, "キーワード", class: "block text-xs font-medium text-zinc-500" %>
+        <%= form.text_field :keyword, value: params[:keyword], placeholder: "タイトル・本文の部分一致", class: "mt-1 block w-full rounded-md border-zinc-300 shadow-sm sm:text-sm" %>
+      </div>
+      <%= form.submit "検索", class: "rounded-md bg-zinc-700 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-zinc-600 cursor-pointer" %>
+      <%= link_to "クリア", admin_adr_management_adrs_path, class: "text-sm text-zinc-500 hover:text-zinc-700" %>
     </div>
-    <div class="grow max-w-xs">
-      <%= form.label :keyword, "キーワード", class: "block text-xs font-medium text-zinc-500" %>
-      <%= form.text_field :keyword, value: params[:keyword], placeholder: "タイトル・本文の部分一致", class: "mt-1 block w-full rounded-md border-zinc-300 shadow-sm sm:text-sm" %>
-    </div>
-    <%= form.submit "絞り込み", class: "rounded-md bg-zinc-700 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-zinc-600 cursor-pointer" %>
-    <%= link_to "クリア", admin_adr_management_adrs_path, class: "text-sm text-zinc-500 hover:text-zinc-700" %>
   <% end %>
 </div>
 
@@ -34,6 +45,9 @@
         <th class="px-6 py-3 text-left text-xs font-medium text-zinc-500 uppercase tracking-wider">ステータス</th>
         <th class="px-6 py-3 text-left text-xs font-medium text-zinc-500 uppercase tracking-wider">信頼度</th>
         <th class="px-6 py-3 text-left text-xs font-medium text-zinc-500 uppercase tracking-wider">決定日</th>
+        <% if @relevance_scores %>
+          <th class="px-6 py-3 text-left text-xs font-medium text-zinc-500 uppercase tracking-wider">関連度</th>
+        <% end %>
       </tr>
     </thead>
     <tbody class="bg-white divide-y divide-zinc-200">
@@ -45,11 +59,16 @@
           <td class="px-6 py-4 whitespace-nowrap text-sm text-zinc-500"><%= adr_status_label(adr.status) %></td>
           <td class="px-6 py-4 whitespace-nowrap text-sm text-zinc-500"><%= adr_confidence_label(adr.confidence) %></td>
           <td class="px-6 py-4 whitespace-nowrap text-sm text-zinc-500"><%= adr.decided_on %></td>
+          <% if @relevance_scores %>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-zinc-500"><%= number_with_precision(@relevance_scores[adr.id], precision: 3) %></td>
+          <% end %>
         </tr>
       <% end %>
       <% if @adrs.empty? %>
         <tr>
-          <td colspan="6" class="px-6 py-4 text-center text-sm text-zinc-500">ADR がありません</td>
+          <td colspan="<%= @relevance_scores ? 7 : 6 %>" class="px-6 py-4 text-center text-sm text-zinc-500">
+            <%= @relevance_scores ? "該当する ADR は見つかりませんでした。別の言い回しやキーワード検索も試してください" : "ADR がありません" %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/adr_management/adrs/show.html.erb
+++ b/app/views/admin/adr_management/adrs/show.html.erb
@@ -106,6 +106,49 @@
 
 <div class="bg-white shadow rounded-lg overflow-hidden mb-6">
   <div class="px-6 py-4 border-b border-zinc-200">
+    <h2 class="text-lg font-medium text-zinc-900">品質所見</h2>
+    <p class="text-sm text-zinc-500 mt-1">
+      層ごとの最新の評価結果です。所見は参考情報で、処理（修正した・誤検知として却下）は
+      <%= link_to "品質所見のレビューキュー", admin_adr_management_quality_path, class: "text-indigo-600 hover:text-indigo-900 underline" %>
+      から行います。
+    </p>
+  </div>
+  <div class="divide-y divide-zinc-200">
+    <% @quality_assessments.each do |layer, assessment| %>
+      <div class="px-6 py-4">
+        <div class="flex flex-wrap items-center gap-2 text-sm text-zinc-500">
+          <span class="rounded bg-zinc-100 px-2 py-0.5 text-xs text-zinc-700"><%= adr_quality_layer_label(layer) %></span>
+          <% if assessment %>
+            <span><%= assessment.created_at.strftime("%Y-%m-%d %H:%M") %></span>
+            <span>経路: <%= assessment.origin %></span>
+          <% else %>
+            <span>未評価</span>
+          <% end %>
+        </div>
+        <% if assessment %>
+          <% if assessment.findings.blank? %>
+            <p class="mt-2 text-sm text-zinc-500">所見なし（評価済み・指摘はありません）</p>
+          <% else %>
+            <ul class="mt-2 space-y-2">
+              <% assessment.findings.each do |finding| %>
+                <li class="text-sm">
+                  <span class="rounded px-2 py-0.5 text-xs font-medium <%= adr_finding_result_badge_class(finding["review_result"]) %>"><%= adr_finding_result_label(finding["review_result"]) %></span>
+                  <span class="text-zinc-900"><%= finding["message"] %></span>
+                  <% if finding["field"].present? %>
+                    <span class="text-zinc-500">（対象: <%= finding["field"] %>）</span>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="bg-white shadow rounded-lg overflow-hidden mb-6">
+  <div class="px-6 py-4 border-b border-zinc-200">
     <h2 class="text-lg font-medium text-zinc-900">版履歴</h2>
   </div>
   <div class="divide-y divide-zinc-200">

--- a/app/views/admin/adr_management/quality/show.html.erb
+++ b/app/views/admin/adr_management/quality/show.html.erb
@@ -39,9 +39,11 @@
         <li class="p-4">
           <div class="flex items-center gap-2 text-sm text-zinc-500 mb-1">
             <span><%= assessment.created_at.to_date %></span>
-            <span class="rounded bg-zinc-100 px-2 py-0.5 text-xs"><%= assessment.layer %></span>
-            <span class="font-medium text-zinc-900"><%= assessment.adr.display_number %></span>
-            <span><%= assessment.adr.title %></span>
+            <span class="rounded bg-zinc-100 px-2 py-0.5 text-xs"><%= adr_quality_layer_label(assessment.layer) %></span>
+            <%= link_to admin_adr_management_adr_path(assessment.adr), class: "text-indigo-600 hover:text-indigo-900 underline" do %>
+              <span class="font-medium"><%= assessment.adr.display_number %></span>
+              <span><%= assessment.adr.title %></span>
+            <% end %>
           </div>
           <ul class="mt-2 space-y-3">
             <% assessment.open_findings.each do |finding| %>

--- a/spec/actions/adr_management/search_natural_language_spec.rb
+++ b/spec/actions/adr_management/search_natural_language_spec.rb
@@ -42,24 +42,40 @@ RSpec.describe AdrManagement::SearchNaturalLanguage do
     end
   end
 
-  describe "engagement scope" do
-    it "restricts results to the given engagement" do
+  describe "adr scope" do
+    it "restricts results to the given scope" do
       target = create_indexed_adr([ 1.0, 0.0, 0.0 ])
       create_indexed_adr([ 1.0, 0.0, 0.0 ])
       stub_query_embedding([ 1.0, 0.0, 0.0 ])
 
-      result = described_class.perform(query: "検索", engagement: target.engagement)
+      result = described_class.perform(
+        query: "検索", adr_scope: AdrManagement::Adr.where(engagement: target.engagement)
+      )
 
       expect(result.data.map(&:adr)).to eq([ target ])
     end
 
-    it "searches across engagements when no engagement is given" do
+    it "searches across all adrs when no scope is given" do
       first = create_indexed_adr([ 1.0, 0.0, 0.0 ])
       second = create_indexed_adr([ 0.9, 0.1, 0.0 ])
       stub_query_embedding([ 1.0, 0.0, 0.0 ])
 
       result = described_class.perform(query: "検索")
       expect(result.data.map(&:adr)).to contain_exactly(first, second)
+    end
+
+    # 上位 limit 件へ切り詰めてから絞り込むと、スコアの高い対象外 ADR に
+    # 枠を奪われて結果が目減りする。絞り込みはスコア計算の前に適用する
+    it "applies the scope before truncating to the limit" do
+      3.times { create_indexed_adr([ 1.0, 0.0, 0.0 ], status: "proposed") }
+      target = create_indexed_adr([ 0.5, 0.5, 0.0 ], status: "accepted")
+      stub_query_embedding([ 1.0, 0.0, 0.0 ])
+
+      result = described_class.perform(
+        query: "検索", adr_scope: AdrManagement::Adr.where(status: "accepted"), limit: 3
+      )
+
+      expect(result.data.map(&:adr)).to eq([ target ])
     end
   end
 

--- a/spec/models/adr_management/search_log_spec.rb
+++ b/spec/models/adr_management/search_log_spec.rb
@@ -23,6 +23,33 @@ RSpec.describe AdrManagement::SearchLog do
     end
   end
 
+  describe ".record" do
+    it "stores the search with stringified filters" do
+      engagement = create(:adr_management_engagement)
+
+      log = described_class.record(
+        mode: "natural_language", query: "認証まわりの決定", keyword: "認証",
+        engagement: engagement, filters: { status: "accepted", confidence: nil },
+        results: [ { adr_id: 1, score: 0.87 } ], result_count: 1, origin: "admin:me@example.com"
+      )
+
+      expect(log.mode).to eq("natural_language")
+      expect(log.engagement).to eq(engagement)
+      expect(log.filters).to eq("status" => "accepted")
+      expect(log.results).to eq([ { "adr_id" => 1, "score" => 0.87 } ])
+      expect(log.origin).to eq("admin:me@example.com")
+    end
+
+    # ログは分析用であり検索の契約に含めない（記録失敗で検索を失敗させない）
+    it "does not raise when the record cannot be saved" do
+      expect(Rails.error).to receive(:report).with(instance_of(ActiveRecord::RecordInvalid), handled: true)
+
+      expect {
+        described_class.record(mode: "unknown", results: [], result_count: 0, origin: "admin:me@example.com")
+      }.not_to raise_error
+    end
+  end
+
   describe ".pending_review" do
     it "returns zero-result logs that have not been reviewed" do
       pending = create(:adr_management_search_log, result_count: 0)

--- a/spec/requests/admin/adr_management/adrs_spec.rb
+++ b/spec/requests/admin/adr_management/adrs_spec.rb
@@ -33,6 +33,78 @@ RSpec.describe "Admin::AdrManagement::Adrs", type: :request do
     end
   end
 
+  describe "GET /admin/adr/adrs (自然言語検索)" do
+    def create_indexed_adr(vector, **attributes)
+      adr = create(:adr_management_adr, { engagement: engagement }.merge(attributes))
+      adr.chunks.create!(kind: "decision", content: adr.decision, state: "fresh",
+        embedding: vector.pack("f*"))
+      adr
+    end
+
+    def stub_query_embedding(vector)
+      stub_request(:post, Sakura::EmbeddingClient::ENDPOINT.to_s).to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { data: [ { embedding: vector, index: 0 } ] }.to_json
+      )
+    end
+
+    it "lists adrs in relevance order with their scores" do
+      create_indexed_adr([ 1.0, 0.0, 0.0 ], title: "近い決定")
+      create_indexed_adr([ 0.0, 1.0, 0.0 ], title: "遠い決定")
+      stub_query_embedding([ 1.0, 0.1, 0.0 ])
+
+      get admin_adr_management_adrs_path, params: { query: "認証まわりで過去に決めたことは？" }
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("関連度</th>")
+      expect(response.body.index("近い決定")).to be < response.body.index("遠い決定")
+    end
+
+    it "narrows the candidates by the attribute and keyword filters" do
+      create_indexed_adr([ 1.0, 0.0, 0.0 ], title: "認証方式の選定", status: "accepted")
+      create_indexed_adr([ 1.0, 0.0, 0.0 ], title: "認証まわりの提案", status: "proposed")
+      create_indexed_adr([ 1.0, 0.0, 0.0 ], title: "デプロイ手順の決定", status: "accepted")
+      stub_query_embedding([ 1.0, 0.0, 0.0 ])
+
+      get admin_adr_management_adrs_path,
+        params: { query: "認証について", status: "accepted", keyword: "認証" }
+
+      expect(response.body).to include("認証方式の選定")
+      expect(response.body).not_to include("認証まわりの提案")
+      expect(response.body).not_to include("デプロイ手順の決定")
+    end
+
+    it "records the search with the admin origin" do
+      create_indexed_adr([ 1.0, 0.0, 0.0 ])
+      stub_query_embedding([ 1.0, 0.0, 0.0 ])
+
+      get admin_adr_management_adrs_path,
+        params: { query: "認証について", engagement_id: engagement.id, status: "accepted" }
+
+      log = ::AdrManagement::SearchLog.last
+      expect(log.mode).to eq("natural_language")
+      expect(log.query).to eq("認証について")
+      expect(log.engagement).to eq(engagement)
+      expect(log.filters).to eq("status" => "accepted")
+      expect(log.result_count).to eq(1)
+      expect(log.origin).to eq("admin:test@takeyuweb.co.jp")
+    end
+
+    it "falls back to the filtered list with an alert when the embedding api is down" do
+      create_indexed_adr([ 1.0, 0.0, 0.0 ], title: "既存の決定")
+      stub_request(:post, Sakura::EmbeddingClient::ENDPOINT.to_s).to_return(status: 500)
+
+      get admin_adr_management_adrs_path, params: { query: "認証について" }
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("自然言語検索を実行できません")
+      expect(response.body).to include("既存の決定")
+      expect(response.body).not_to include("関連度</th>")
+      expect(::AdrManagement::SearchLog.count).to eq(0)
+    end
+  end
+
   describe "GET /admin/adr/adrs/:id" do
     it "renders the body as markdown and shows revisions" do
       adr = create(:adr_management_adr, engagement: engagement,

--- a/spec/requests/admin/adr_management/adrs_spec.rb
+++ b/spec/requests/admin/adr_management/adrs_spec.rb
@@ -69,6 +69,40 @@ RSpec.describe "Admin::AdrManagement::Adrs", type: :request do
       expect(response).to have_http_status(:success)
     end
 
+    it "shows the latest quality assessment of each layer with the finding state" do
+      adr = create(:adr_management_adr, engagement: engagement)
+      create(:adr_management_quality_assessment, adr: adr, layer: "rule",
+        content_fingerprint: "a" * 64, origin: "admin:old@example.com",
+        reviewed_at: Time.current, created_at: 2.days.ago, findings: [
+          { "code" => "alternatives_missing", "field" => "alternatives",
+            "message" => "旧版の所見", "review_result" => "addressed" }
+        ])
+      create(:adr_management_quality_assessment, adr: adr, layer: "rule",
+        origin: "admin:new@example.com", created_at: 1.day.ago, findings: [
+          { "code" => "status_quo_missing", "field" => "alternatives",
+            "message" => "現状維持案の検討が見当たりません" }
+        ])
+
+      get admin_adr_management_adr_path(adr)
+
+      expect(response.body).to include("品質所見", "現状維持案の検討が見当たりません", "未処理")
+      expect(response.body).to include("admin:new@example.com")
+      # 層ごとに最新の1件のみを表示する
+      expect(response.body).not_to include("旧版の所見")
+      # 評価が無い層は未評価として示す
+      expect(response.body).to include("LLM", "未評価")
+    end
+
+    it "shows an assessed ADR without findings as having none" do
+      adr = create(:adr_management_adr, engagement: engagement)
+      create(:adr_management_quality_assessment, adr: adr, layer: "rule",
+        findings: [], reviewed_at: Time.current)
+
+      get admin_adr_management_adr_path(adr)
+
+      expect(response.body).to include("所見なし")
+    end
+
     it "shows the supersession chain" do
       old_adr = create(:adr_management_adr, engagement: engagement, status: "accepted", title: "旧決定")
       result = AdrManagement::RegisterAdr.perform(

--- a/spec/requests/admin/adr_management/quality_spec.rb
+++ b/spec/requests/admin/adr_management/quality_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe "Admin AdrManagement Quality", type: :request do
       expect(response.body).to include("代替案が記録されていません", "修正した", "誤検知として却下")
     end
 
+    it "links each queued finding to the ADR detail page" do
+      adr = create(:adr_management_adr)
+      create(:adr_management_quality_assessment, adr: adr)
+
+      get "/admin/adr/quality"
+
+      expect(response.body).to include(%(href="#{admin_adr_management_adr_path(adr)}"))
+    end
+
     it "hides reviewed assessments from the queue" do
       assessment = create(:adr_management_quality_assessment, reviewed_at: Time.current, findings: [
         { "code" => "alternatives_missing", "field" => "alternatives",


### PR DESCRIPTION
## 概要

ADR 一覧の検索に自然言語検索を追加する。

ADR 一覧の検索は `LIKE` の部分一致のみで、埋め込みによる自然言語検索（SPOTLIGHT-RAILS-27）は MCP ツール経由でしか使えなかった。管理画面と Agent で検索手段が非対称なため、管理者が「認証まわりで過去に決めたことは？」のような問いから ADR に辿り着けず、語彙が一致する検索語を自分で組み立てる必要があった。

既存の `SearchNaturalLanguage`（さくらのAI Engine の埋め込み + ローカルのコサイン類似度）を管理画面に接続する。新方式の導入ではないため ADR の追加登録は行っていない。

## 変更内容

### 絞り込みはスコア計算の前に適用する

上位 N 件へ切り詰めてから絞り込むと、条件に合う ADR が N 件未満しか残らず結果が目減りする。これを避けるため `SearchNaturalLanguage` の `engagement:` 引数を、ADR のリレーションを受け取る `adr_scope:` に置き換え、案件・ステータス・キーワードを SQL 側（チャンク取得段階）で表現する。

- キーワードと自然言語検索の併用が可能になる（AND 絞り込み → 関連度順）
- MCP ツールは呼び出し口を追随させるのみ。**外部契約・挙動は変えていない**

### 管理画面からの検索も SearchLog に記録する

0件検索が管理画面のレビューキューに載り、検索品質レポートの母数が Agent 経由の検索だけに偏らないようにするため。記録処理は MCP ツールと共通化し `SearchLog.record` に集約した（ベストエフォート方針も同メソッドに集約）。

### 縮退動作

埋め込み API の障害時は画面を失敗させず、`flash.now[:alert]` を出して絞り込みのみの一覧に縮退する。索引は自然言語検索専用であり、DB を参照する一覧は索引が古くても正しさを保つ（機能設計書 3.3 の契約）。

### 画面

- 検索フォームに自然言語検索の入力欄を追加（取得上限 30 件）
- 自然言語検索時のみ「関連度」列を表示し、関連度順に並べる
- 0件時は「別の言い回しやキーワード検索も試してください」に文言を切り替え（MCP ツールの 0 件ガイダンスと同趣旨）

## 検証

- 全 1029 テスト通過、RuboCop 違反なし
- MCP ツールの既存テストは無修正で通過（`adr_scope:` 置き換えによる挙動不変を担保）
- 追加テスト:
  - 事前絞り込みの検証（スコアの高い対象外 ADR に枠を奪われないこと）
  - 管理画面: 関連度順の表示、属性・キーワードによる候補の絞り込み、`admin:<メール>` での検索ログ記録、埋め込み API 障害時の縮退
  - `SearchLog.record` の単体テスト（フィルタの文字列化、保存失敗時に例外を投げないこと）

## 補足・残課題

MCP ツールの自然言語検索は、`adr_scope:` で事前絞り込みが可能になった後も `matches_filters?` による事後絞り込みのままとした。修正すると Agent 向けのツール説明文に明記した非網羅性の記述と挙動が変わるため、本 PR のスコープからは外している。

管理画面での試行錯誤が検索品質指標（0件率・ログ件数の 10 万件閾値）に混ざるため、将来 `origin` での切り分けが必要になる可能性がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)