### PR TITLE
fix(observability): OTLP トレースのメタ情報付与とノイズ除外

### DIFF
--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -10,6 +10,14 @@ if Rails.env.development? || Rails.env.production?
 
   OpenTelemetry::SDK.configure do |c|
     c.service_name = "spotlight-rails"
+    # Sentry の OTLP 取り込みは resource 属性 deployment.environment.name を
+    # スパン属性 sentry.environment にバックフィルする。これを付けないと
+    # トレースに環境が入らず、development と production を分離できない。
+    # エラーイベント・ログの環境は SDK が RAILS_ENV から自動で設定するため、
+    # 出所を揃える目的でここでも Rails.env を使う。
+    c.resource = OpenTelemetry::SDK::Resources::Resource.create(
+      "deployment.environment.name" => Rails.env.to_s
+    )
     c.use "OpenTelemetry::Instrumentation::Rails"
     c.use "OpenTelemetry::Instrumentation::Faraday"
     c.use "OpenTelemetry::Instrumentation::Net::HTTP"

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -18,13 +18,19 @@ if Rails.env.development? || Rails.env.production?
     c.resource = OpenTelemetry::SDK::Resources::Resource.create(
       "deployment.environment.name" => Rails.env.to_s
     )
-    c.use "OpenTelemetry::Instrumentation::Rails"
-    c.use "OpenTelemetry::Instrumentation::Faraday"
-    c.use "OpenTelemetry::Instrumentation::Net::HTTP"
-    # プロンプト・出力本文をスパンに含めるかは環境変数
+    # use_all で登録済みの全計装（Rails の各コンポーネント・Faraday・
+    # Net::HTTP・RubyLLM）を有効化する。個別に use "OpenTelemetry::
+    # Instrumentation::Rails" とするのは誤りで、アンブレラ計装の install は
+    # no-op のため Rack・ActionPack・ActiveRecord 等のサブ計装が入らず、
+    # リクエスト・DB・ジョブのスパンが一切生成されない。
+    #
+    # プロンプト・出力本文を RubyLLM のスパンに含めるかは環境変数
     # OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT で制御する。
     # 計装 gem の既定は含めないため、開発は .devcontainer/devcontainer.json、
     # 本番は config/deploy.yml で明示的に true を与えている
-    c.use "OpenTelemetry::Instrumentation::RubyLLM"
+    c.use_all(
+      # ヘルスチェックはトレース対象から除外する
+      "OpenTelemetry::Instrumentation::Rack" => { untraced_endpoints: [ "/up" ] }
+    )
   end
 end

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -30,7 +30,11 @@ if Rails.env.development? || Rails.env.production?
     # 本番は config/deploy.yml で明示的に true を与えている
     c.use_all(
       # ヘルスチェックはトレース対象から除外する
-      "OpenTelemetry::Instrumentation::Rack" => { untraced_endpoints: [ "/up" ] }
+      "OpenTelemetry::Instrumentation::Rack" => { untraced_endpoints: [ "/up" ] },
+      # Sentry へのテレメトリ送信（エラー・ログのエンベロープ POST）自体が
+      # トレースされる自己計測を防ぐ。OTLP エクスポータは自前で untraced
+      # ラップするため対象外だが、sentry-ruby SDK の送信はラップされない
+      "OpenTelemetry::Instrumentation::Net::HTTP" => { untraced_hosts: [ /\.sentry\.io\z/ ] }
     )
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require Rails.root.join("lib/observability/log_drop_filter")
+
 Sentry.init do |config|
   config.breadcrumbs_logger = [ :active_support_logger ]
   config.dsn = "https://4c9c655faa3ad26cb0a278bd3c88b1b6@o135775.ingest.us.sentry.io/4510050183479296"
@@ -7,6 +9,13 @@ Sentry.init do |config|
   config.enable_logs = true
   config.enabled_patches << :logger
   config.rails.structured_logging.enabled = true
+
+  # トレースと同様にノイズになるログは送信しない：
+  # - Solid アダプタ内部の動作ログ（SpanDropExporter の除外対象と対応）
+  # - ヘルスチェックのコントローラログ（Rack 計装の untraced_endpoints と対応）
+  config.before_send_log = Observability::LogDropFilter.new(
+    /\bSolid(?:Queue|Cache|Cable)\b|\bRails::HealthController\b/
+  )
 
   # テスト環境では無効化
   config.enabled_environments = %w[development production]

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -28,6 +28,16 @@ end
 # 差し替える拡張点がないため自前で行っている。
 if Rails.env.development? || Rails.env.production?
   require Rails.root.join("lib/observability/gen_ai_content_filter_exporter")
+  require Rails.root.join("lib/observability/sentry_release_span_processor")
+
+  # リリースはスパン属性でしか渡せないため、エクスポート前に全スパンへ付与する。
+  # 環境（deployment.environment.name）は resource 属性として
+  # config/initializers/opentelemetry.rb で設定済み。
+  if (release = Sentry.configuration.release)
+    OpenTelemetry.tracer_provider.add_span_processor(
+      Observability::SentryReleaseSpanProcessor.new(release)
+    )
+  end
 
   dsn = Sentry.configuration.dsn
   otlp_exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -28,6 +28,7 @@ end
 # 差し替える拡張点がないため自前で行っている。
 if Rails.env.development? || Rails.env.production?
   require Rails.root.join("lib/observability/gen_ai_content_filter_exporter")
+  require Rails.root.join("lib/observability/span_drop_exporter")
   require Rails.root.join("lib/observability/sentry_release_span_processor")
 
   # リリースはスパン属性でしか渡せないため、エクスポート前に全スパンへ付与する。
@@ -46,7 +47,12 @@ if Rails.env.development? || Rails.env.production?
   )
   OpenTelemetry.tracer_provider.add_span_processor(
     OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-      Observability::GenAiContentFilterExporter.new(otlp_exporter)
+      # Solid アダプタ内部の DB アクセススパンはノイズのため除外してから
+      # マスキングを適用する
+      Observability::SpanDropExporter.new(
+        Observability::GenAiContentFilterExporter.new(otlp_exporter),
+        name_prefixes: %w[SolidQueue:: SolidCache:: SolidCable::]
+      )
     )
   )
 end

--- a/lib/observability/log_drop_filter.rb
+++ b/lib/observability/log_drop_filter.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Observability
+  # before_send_log フックとして登録し、本文がパターンに一致するログを
+  # 送信前に破棄する（nil を返すと SDK が破棄する）。
+  #
+  # SolidQueue・SolidCable などフレームワーク内部の動作は、トレース
+  # （SpanDropExporter で除外）だけでなくログにも大量に現れる：
+  # - ActiveJob のジョブ実行ログ（Performed SolidCable::TrimJob ... 等）
+  # - structured_logging の DB クエリログ（Database query: SolidCable::Message Insert 等）
+  # - SolidQueue スーパーバイザ自身のログ
+  # いずれも本文にコンポーネント名を含むため、本文の一致で判定する。
+  class LogDropFilter
+    def initialize(pattern)
+      @pattern = pattern
+    end
+
+    def call(log)
+      log.body&.match?(@pattern) ? nil : log
+    end
+  end
+end

--- a/lib/observability/sentry_release_span_processor.rb
+++ b/lib/observability/sentry_release_span_processor.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Observability
+  # 全スパンに Sentry のリリース識別子（sentry.release）を付与する SpanProcessor。
+  #
+  # Sentry の OTLP 取り込みは、環境については resource 属性
+  # deployment.environment.name をスパン属性 sentry.environment へ変換するが
+  # （config/initializers/opentelemetry.rb を参照）、リリースには resource 属性
+  # からの変換経路がない。resource 属性は取り込み時に resource. が前置されるため、
+  # sentry.release という名前で resource に置いても認識されない。
+  # そのためスパン属性として直接付与する必要がある。
+  #
+  # 属性は終了済みのスパンには設定できないため、エクスポータではなく
+  # SpanProcessor#on_start で付与する。
+  class SentryReleaseSpanProcessor < OpenTelemetry::SDK::Trace::SpanProcessor
+    RELEASE_ATTRIBUTE_KEY = "sentry.release"
+
+    def initialize(release)
+      super()
+      @release = release
+    end
+
+    def on_start(span, _parent_context)
+      span.set_attribute(RELEASE_ATTRIBUTE_KEY, @release)
+    end
+  end
+end

--- a/lib/observability/span_drop_exporter.rb
+++ b/lib/observability/span_drop_exporter.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Observability
+  # スパン名のプレフィックスに一致するスパンをエクスポートから除外する
+  # エクスポータの委譲ラッパー。
+  #
+  # SolidQueue・SolidCable などフレームワーク内部の DB アクセスは
+  # ActiveRecord 計装によりモデル名のスパン（例: SolidQueue::ReadyExecution.create）
+  # として大量に生成され、アプリの動作把握には不要なため送信前に落とす。
+  # ジョブ自体のスパン（ActiveJob 計装によるキュー名の publish / process）は
+  # プレフィックスに一致しないため残る。
+  #
+  # 除外対象のスパンは子を持たない（ActiveRecord 計装のスパンは末端）ため、
+  # 除外によって残したスパンの親が欠けることはない。
+  class SpanDropExporter
+    def initialize(exporter, name_prefixes:)
+      @exporter = exporter
+      @name_prefixes = name_prefixes
+    end
+
+    def export(span_datas, timeout: nil)
+      kept = span_datas.reject { |span_data| drop?(span_data) }
+      return OpenTelemetry::SDK::Trace::Export::SUCCESS if kept.empty?
+
+      @exporter.export(kept, timeout: timeout)
+    end
+
+    def force_flush(timeout: nil)
+      @exporter.force_flush(timeout: timeout)
+    end
+
+    def shutdown(timeout: nil)
+      @exporter.shutdown(timeout: timeout)
+    end
+
+    private
+
+    def drop?(span_data)
+      @name_prefixes.any? { |prefix| span_data.name&.start_with?(prefix) }
+    end
+  end
+end

--- a/lib/observability/span_drop_exporter.rb
+++ b/lib/observability/span_drop_exporter.rb
@@ -7,12 +7,14 @@ module Observability
   # SolidQueue・SolidCable などフレームワーク内部の DB アクセスは
   # ActiveRecord 計装によりモデル名のスパン（例: SolidQueue::ReadyExecution.create）
   # として大量に生成され、アプリの動作把握には不要なため送信前に落とす。
+  # トランザクションのスパンだけは固定名 ActiveRecord.transaction で
+  # モデル名が code.namespace 属性に入るため、名前に加えて属性も判定する。
   # ジョブ自体のスパン（ActiveJob 計装によるキュー名の publish / process）は
-  # プレフィックスに一致しないため残る。
-  #
-  # 除外対象のスパンは子を持たない（ActiveRecord 計装のスパンは末端）ため、
-  # 除外によって残したスパンの親が欠けることはない。
+  # どちらにも一致しないため残る。
   class SpanDropExporter
+    CODE_NAMESPACE_ATTRIBUTE_KEY = "code.namespace"
+    private_constant :CODE_NAMESPACE_ATTRIBUTE_KEY
+
     def initialize(exporter, name_prefixes:)
       @exporter = exporter
       @name_prefixes = name_prefixes
@@ -36,7 +38,10 @@ module Observability
     private
 
     def drop?(span_data)
-      @name_prefixes.any? { |prefix| span_data.name&.start_with?(prefix) }
+      code_namespace = span_data.attributes&.[](CODE_NAMESPACE_ATTRIBUTE_KEY)
+      @name_prefixes.any? do |prefix|
+        span_data.name&.start_with?(prefix) || code_namespace&.start_with?(prefix)
+      end
     end
   end
 end

--- a/spec/lib/observability/log_drop_filter_spec.rb
+++ b/spec/lib/observability/log_drop_filter_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("lib/observability/log_drop_filter")
+
+RSpec.describe Observability::LogDropFilter do
+  let(:filter) { described_class.new(/\bSolid(?:Queue|Cache|Cable)\b|\bRails::HealthController\b/) }
+
+  def build_log(body)
+    Sentry::LogEvent.new(level: :info, body: body)
+  end
+
+  describe "#call" do
+    it "ジョブ実行ログを破棄する" do
+      log = build_log("Performed SolidCable::TrimJob (Job ID: e057ae0e) from SolidQueue(default) in 0.32ms")
+
+      expect(filter.call(log)).to be_nil
+    end
+
+    it "structured_logging の DB クエリログを破棄する" do
+      log = build_log("Database query: SolidQueue::Process Update")
+
+      expect(filter.call(log)).to be_nil
+    end
+
+    it "ヘルスチェックのコントローラログを破棄する" do
+      log = build_log("Rails::HealthController#show")
+
+      expect(filter.call(log)).to be_nil
+    end
+
+    it "パターンに一致しないログはそのまま返す" do
+      log = build_log("Database query: Adr Load")
+
+      expect(filter.call(log)).to be(log)
+    end
+
+    it "本文が nil のログはそのまま返す" do
+      # LogEvent は body なしで構築できないため、防御的分岐はスタブで検証する
+      log = instance_double(Sentry::LogEvent, body: nil)
+
+      expect(filter.call(log)).to be(log)
+    end
+  end
+end

--- a/spec/lib/observability/sentry_release_span_processor_spec.rb
+++ b/spec/lib/observability/sentry_release_span_processor_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("lib/observability/sentry_release_span_processor")
+
+RSpec.describe Observability::SentryReleaseSpanProcessor do
+  let(:exporter) { OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new }
+
+  let(:tracer_provider) do
+    OpenTelemetry::SDK::Trace::TracerProvider.new.tap do |provider|
+      provider.add_span_processor(described_class.new("abc123"))
+      provider.add_span_processor(OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(exporter))
+    end
+  end
+
+  after { tracer_provider.shutdown }
+
+  it "エクスポートされるスパンに sentry.release を付与する" do
+    tracer_provider.tracer("test").in_span("some span") { }
+
+    expect(exporter.finished_spans.first.attributes).to include("sentry.release" => "abc123")
+  end
+
+  it "子スパンにも付与する" do
+    tracer_provider.tracer("test").in_span("parent") do
+      tracer_provider.tracer("test").in_span("child") { }
+    end
+
+    expect(exporter.finished_spans.map { |span| span.attributes["sentry.release"] }).to eq([ "abc123", "abc123" ])
+  end
+
+  it "計装が設定した属性を保持する" do
+    tracer_provider.tracer("test").in_span("some span", attributes: { "gen_ai.system" => "anthropic" }) { }
+
+    expect(exporter.finished_spans.first.attributes).to include(
+      "gen_ai.system" => "anthropic",
+      "sentry.release" => "abc123"
+    )
+  end
+end

--- a/spec/lib/observability/span_drop_exporter_spec.rb
+++ b/spec/lib/observability/span_drop_exporter_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("lib/observability/span_drop_exporter")
+
+RSpec.describe Observability::SpanDropExporter do
+  let(:inner_exporter) { OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new }
+  let(:exporter) do
+    described_class.new(inner_exporter, name_prefixes: %w[SolidQueue:: SolidCache:: SolidCable::])
+  end
+
+  def build_span_data(name)
+    OpenTelemetry::SDK::Trace::SpanData.new.tap { |span_data| span_data.name = name }
+  end
+
+  describe "#export" do
+    it "プレフィックスに一致するスパンを除外し、それ以外を送信する" do
+      result = exporter.export(
+        [
+          build_span_data("SolidQueue::ReadyExecution.create"),
+          build_span_data("SolidCable::Message.create"),
+          build_span_data("default process"),
+          build_span_data("chat anthropic")
+        ]
+      )
+
+      expect(result).to eq(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+      expect(inner_exporter.finished_spans.map(&:name)).to eq([ "default process", "chat anthropic" ])
+    end
+
+    it "全スパンが除外対象の場合は内側のエクスポータを呼ばず成功を返す" do
+      result = exporter.export([ build_span_data("SolidQueue::Process.update") ])
+
+      expect(result).to eq(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+      expect(inner_exporter.finished_spans).to be_empty
+    end
+
+    it "プレフィックスは前方一致のみで、部分一致では除外しない" do
+      exporter.export([ build_span_data("Admin::SolidQueueDashboard#show") ])
+
+      expect(inner_exporter.finished_spans.map(&:name)).to eq([ "Admin::SolidQueueDashboard#show" ])
+    end
+  end
+end

--- a/spec/lib/observability/span_drop_exporter_spec.rb
+++ b/spec/lib/observability/span_drop_exporter_spec.rb
@@ -9,8 +9,11 @@ RSpec.describe Observability::SpanDropExporter do
     described_class.new(inner_exporter, name_prefixes: %w[SolidQueue:: SolidCache:: SolidCable::])
   end
 
-  def build_span_data(name)
-    OpenTelemetry::SDK::Trace::SpanData.new.tap { |span_data| span_data.name = name }
+  def build_span_data(name, attributes: nil)
+    OpenTelemetry::SDK::Trace::SpanData.new.tap do |span_data|
+      span_data.name = name
+      span_data.attributes = attributes
+    end
   end
 
   describe "#export" do
@@ -39,6 +42,18 @@ RSpec.describe Observability::SpanDropExporter do
       exporter.export([ build_span_data("Admin::SolidQueueDashboard#show") ])
 
       expect(inner_exporter.finished_spans.map(&:name)).to eq([ "Admin::SolidQueueDashboard#show" ])
+    end
+
+    it "code.namespace 属性がプレフィックスに一致するスパンを除外する" do
+      exporter.export(
+        [
+          build_span_data("ActiveRecord.transaction", attributes: { "code.namespace" => "SolidQueue::ReadyExecution" }),
+          build_span_data("ActiveRecord.transaction", attributes: { "code.namespace" => "ApplicationRecord" })
+        ]
+      )
+
+      expect(inner_exporter.finished_spans.size).to eq(1)
+      expect(inner_exporter.finished_spans.first.attributes).to eq({ "code.namespace" => "ApplicationRecord" })
     end
   end
 end


### PR DESCRIPTION
## 概要

LLM トレーシングの OTel 移行（#51 以前の #22ffb14 系）後に生じていた、OTLP トレースの欠落・ノイズをまとめて修正する。

## 背景

Sentry SDK ネイティブトレーシングから OTel 計装 + OTLP 取り込みへ移行した際、ネイティブでは自動で付いていたメタ情報が欠落し、また計装の誤設定・過剰計装が残っていた。

## 変更内容

### 欠落の修正

- **環境の付与** (cdadd74): resource 属性 `deployment.environment.name` に `Rails.env` を設定。Sentry の OTLP 取り込みがスパン属性 `sentry.environment` へバックフィルする
- **リリースの付与** (be1b4da): リリースには resource 属性からの変換経路がないため、`SentryReleaseSpanProcessor` で全スパンにスパン属性 `sentry.release` を直接付与。値は Sentry SDK の検出結果（`SENTRY_RELEASE` → `KAMAL_VERSION` → git SHA）を流用
- **Rails サブ計装の有効化** (172bab5): `use "OpenTelemetry::Instrumentation::Rails"` はアンブレラ計装で install が no-op のため、Rack・ActionPack・ActiveRecord・ActiveJob 等が未インストールとなり、リクエスト・DB・ジョブのスパンが一切生成されていなかった。README 推奨の `use_all` に変更。あわせてヘルスチェック `/up` を除外

### ノイズの除外

- **Solid アダプタ内部のスパン** (354a1b4, 1bf2546): SolidQueue のポーリング等による ActiveRecord スパンを `SpanDropExporter` で送信前に除外。スパン名の前方一致（`SolidQueue::` 等）に加え、固定名 `ActiveRecord.transaction` のスパンは `code.namespace` 属性で判定。ジョブ自体のスパン（ActiveJob 計装の publish / process）は残す
- **テレメトリ送信の自己計測** (faabd15): sentry-ruby SDK のエンベロープ送信が Net::HTTP 計装に捕捉されていたため、`untraced_hosts` に sentry.io を指定

## 検証

- rspec `spec/lib/observability/` 16 examples, 0 failures / rubocop offense なし
- 実環境で計装のインストール状態・resource 属性・`untraced_hosts` の反映を確認
- 本番デプロイ済みのコミットでは、環境（production）・リリースがトレースに付与されることを Sentry 上で確認済み（環境・Solid 除外・自己計測除外は本番トレースのスクリーンショットで実証）

## デプロイ後の確認事項

- [ ] リクエスト起点トレース（`GET /...` ルート）に DB・LLM スパンがぶら下がる
- [ ] `ActiveRecord.transaction`（SolidQueue 由来）の単発トレースが新規に出ない
- [ ] `http.client — POST https://o135775.ingest.us.sentry.io` の単発トレースが新規に出ない
- [ ] `/up` がトレースされない

🤖 Generated with [Claude Code](https://claude.com/claude-code)